### PR TITLE
GH-64 :: Make the scripts independent of what folder the user ru…

### DIFF
--- a/scripts/CIStore.ps1
+++ b/scripts/CIStore.ps1
@@ -3,16 +3,15 @@
     Serializes database data to the continuous integration repository.
 #>
 
-$scriptsPath = Get-Location
-
-Set-Location -Path ../src/TrainingGuides.Web
+$originalLocation = Get-Location
+Set-Location -Path $PSScriptRoot/../src/TrainingGuides.Web
 
 Write-Host 'Storing CI files'
 
 dotnet run --no-build --kxp-ci-store
 
 if ($LASTEXITCODE -ne 0) {
-    Set-Location -Path $scriptsPath
+    Set-Location -Path $originalLocation
     Write-Error "CI store failed."
     Read-Host -Prompt "Press Enter to exit"
     exit 1
@@ -21,6 +20,6 @@ else{
     Write-Host 'CI files stored'
 }
 
-Set-Location -Path $scriptsPath
+Set-Location -Path $originalLocation
 
 Read-Host -Prompt "Press Enter to exit"

--- a/scripts/GenerateCodeFiles.ps1
+++ b/scripts/GenerateCodeFiles.ps1
@@ -4,8 +4,8 @@
 #>
 $exitCode = 0
 
-$scriptsPath = Get-Location
-Set-Location -Path ../src/TrainingGuides.Web
+$originalLocation = Get-Location
+Set-Location -Path $PSScriptRoot/../src/TrainingGuides.Web
 
 # https://docs.xperience.io/xp/developers-and-admins/development/content-retrieval/generate-code-files-for-xperience-objects
 
@@ -57,12 +57,12 @@ else{
 }
 Write-Host
 
-Set-Location -Path $scriptsPath
-
 if ($exitCode -ne 0) {
+    Set-Location -Path $originalLocation
     Write-Error "Completed with errors. See above."
     Read-Host -Prompt "Press Enter to exit"
     exit $exitCode
 }
 
+Set-Location -Path $originalLocation
 Read-Host -Prompt "Press Enter to exit"

--- a/scripts/Get-ConnectionString.ps1
+++ b/scripts/Get-ConnectionString.ps1
@@ -9,7 +9,8 @@
 #>
 function Get-ConnectionString {
     param(
-        [string] $Path
+        [string] $Path,
+        [string] $OriginalLocation
     )
 
     # Try to get the connection string from user secrets first
@@ -43,8 +44,9 @@ function Get-ConnectionString {
                 return $connectionString;
             }
         }
-    }
-    
+    }    
+
+    Set-Location $OriginalLocation
     Write-Error "Connection string not found."
     Read-Host -Prompt "Press Enter to exit"
     exit 1

--- a/scripts/Publish.ps1
+++ b/scripts/Publish.ps1
@@ -5,7 +5,9 @@
     [CmdletBinding()]
 param ([switch]$KeepProductVersion)
 
-$scriptsPath = Get-Location
+$originalLocation = Get-Location
+Set-Location -Path $PSScriptRoot
+
 $outputFolderPath = "./bin/Deployment/"
 $buildNumber = (Get-Date).ToUniversalTime().ToString("yyyyMMddHHmm")
 
@@ -23,11 +25,11 @@ Write-Host $publishCommand
 Invoke-Expression $publishCommand
 
 if ($LASTEXITCODE -ne 0) {
-    Set-Location -Path $scriptsPath
+    Set-Location -Path $originalLocation
     Write-Error "Publishing the website failed."
     Read-Host -Prompt "Press Enter to exit"
     exit 1
 }
 
-Set-Location -Path $scriptsPath
+Set-Location -Path $originalLocation
 Read-Host -Prompt "Press Enter to exit"

--- a/scripts/Update.ps1
+++ b/scripts/Update.ps1
@@ -6,6 +6,8 @@
 $originalLocation = Get-Location
 Set-Location -Path $PSScriptRoot
 
+. .\Get-ConnectionString.ps1
+
 function Handle-Error {
 	param(
 		[string] $Message
@@ -15,8 +17,6 @@ function Handle-Error {
     Read-Host -Prompt "Press Enter to exit"
     exit 1
 }
-
-. .\Get-ConnectionString.ps1
 
 #Query that executes a command without returning a dataset.
 function Execute-SQL-Command {


### PR DESCRIPTION
Address GH-64 ::
- Make the scripts independent of what folder the user runs them from (using the [$PSScriptRoot](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.4#psscriptroot) variable).
- Ensure the user will not get moved to a different folder if an error occurs.
- Extract error handling into a function in some scripts to avoid repetitive code.