### PR TITLE
GH-112 :: Adjust the 'Form column section: consent-based' Page Builde…

### DIFF
--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
@@ -17,5 +17,10 @@
 }
 else
 {
-    @Model.NoConsentHtml
+    <div>
+        @Model.NoConsentMessage
+    </div>
+    <div>
+        <a href="@Model.NoConsentLinkUrl">@Model.NoConsentLinkText</a>
+    </div>
 }

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
@@ -17,5 +17,5 @@
 }
 else
 {
-    @Model.NoConsentHTML
+    @Model.NoConsentHtml
 }

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml
@@ -1,7 +1,7 @@
 ﻿@using TrainingGuides.Web.Features.Shared.Sections.FormColumn
 @model FormColumnSectionViewModel
 
-@if(Model.ShowContents || Context.Kentico().Preview().Enabled)
+@if(Model.ShowContents)
 {
     var sectionAnchor = !string.IsNullOrWhiteSpace(Model.SectionAnchor) ? $"id={Model.SectionAnchor}" : "";
 
@@ -14,4 +14,8 @@
             </div>
         </div>
     </section>
+}
+else
+{
+    @Model.NoConsentHTML
 }

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
@@ -1,7 +1,13 @@
-﻿using Kentico.PageBuilder.Web.Mvc;
+﻿using CMS.Base.Internal;
+using Kentico.Content.Web.Mvc;
+using Kentico.PageBuilder.Web.Mvc;
+using Kentico.Web.Mvc;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 using TrainingGuides.Web.Features.DataProtection.Services;
 using TrainingGuides.Web.Features.Shared.Sections.FormColumn;
+using TrainingGuides.Web.Features.Shared.Services;
 
 [assembly: RegisterSection(
     identifier: FormColumnSectionConsentViewComponent.IDENTIFIER,
@@ -18,21 +24,45 @@ public class FormColumnSectionConsentViewComponent : ViewComponent
     public const string IDENTIFIER = "TrainingGuides.FormColumnSectionConsent";
 
     private readonly ICookieConsentService cookieConsentService;
+    private readonly IStringLocalizer<SharedResources> stringLocalizer;
+    private readonly IHttpRequestService httpRequestService;
+    private readonly IHttpContextAccessor httpContextAccessor;
 
-    public FormColumnSectionConsentViewComponent(ICookieConsentService cookieConsentService)
+
+    public FormColumnSectionConsentViewComponent(ICookieConsentService cookieConsentService,
+        IStringLocalizer<SharedResources> stringLocalizer,
+        IHttpRequestService httpRequestService,
+        IHttpContextAccessor httpContextAccessor)
     {
         this.cookieConsentService = cookieConsentService;
+        this.stringLocalizer = stringLocalizer;
+        this.httpRequestService = httpRequestService;
+        this.httpContextAccessor = httpContextAccessor;
     }
 
     public IViewComponentResult Invoke(ComponentViewModel<FormColumnSectionProperties> sectionProperties)
     {
-        //If the CMSCookieLevel is set to All (1000) or higher, and Data Protection is set up, it means the visitor has the appropriate consent level for tracking.
-        bool showContents = cookieConsentService.CurrentContactCanBeTracked();
+        var httpContext = httpContextAccessor.HttpContext;
+
+        bool showContents = cookieConsentService.CurrentContactCanBeTracked() // Display if the visitor has consented to tracking.
+            || httpContext.Kentico().PageBuilder().GetMode() != PageBuilderMode.Off // Display if the page is in Page Builder mode.
+            || httpContext.Kentico().Preview().Enabled; // Display if the page is in Preview mode.
+
+        var cookiePolicyUrlBuilder = new UriBuilder(httpRequestService.GetBaseUrlWithLanguage());
+        cookiePolicyUrlBuilder.Path = httpRequestService.CombineUrlPaths(cookiePolicyUrlBuilder.Path, "cookie-policy");
+
+        var noConsentHTML = new HtmlString(
+            "<div>" +
+            stringLocalizer["The content of this section includes tracking functionality. To view it, please consent to Marketing cookies."] +
+            $"</div><div>"
+            + $"<a href=\"{cookiePolicyUrlBuilder}\">{stringLocalizer["Configure cookies"]}</a>"
+            + "</div>");
 
         var model = new FormColumnSectionViewModel()
         {
             SectionAnchor = sectionProperties.Properties.SectionAnchor,
-            ShowContents = showContents
+            ShowContents = showContents,
+            NoConsentHTML = noConsentHTML
         };
 
         return View("~/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml", model);

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
@@ -2,7 +2,6 @@
 using Kentico.Content.Web.Mvc;
 using Kentico.PageBuilder.Web.Mvc;
 using Kentico.Web.Mvc;
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using TrainingGuides.Web.Features.DataProtection.Services;
@@ -51,18 +50,13 @@ public class FormColumnSectionConsentViewComponent : ViewComponent
         var cookiePolicyUrlBuilder = new UriBuilder(httpRequestService.GetBaseUrlWithLanguage());
         cookiePolicyUrlBuilder.Path = httpRequestService.CombineUrlPaths(cookiePolicyUrlBuilder.Path, "cookie-policy");
 
-        var noConsentHtml = new HtmlString(
-            "<div>" +
-            stringLocalizer["The content of this section includes tracking functionality. To view it, please consent to Marketing cookies."] +
-            $"</div><div>"
-            + $"<a href=\"{cookiePolicyUrlBuilder}\">{stringLocalizer["Configure cookies"]}</a>"
-            + "</div>");
-
         var model = new FormColumnSectionViewModel()
         {
             SectionAnchor = sectionProperties.Properties.SectionAnchor,
             ShowContents = showContents,
-            NoConsentHtml = noConsentHtml
+            NoConsentMessage = stringLocalizer["The content of this section includes tracking functionality. To view it, please consent to Marketing cookies."],
+            NoConsentLinkText = stringLocalizer["Configure cookies"],
+            NoConsentLinkUrl = cookiePolicyUrlBuilder.ToString()
         };
 
         return View("~/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml", model);

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionConsentViewComponent.cs
@@ -51,7 +51,7 @@ public class FormColumnSectionConsentViewComponent : ViewComponent
         var cookiePolicyUrlBuilder = new UriBuilder(httpRequestService.GetBaseUrlWithLanguage());
         cookiePolicyUrlBuilder.Path = httpRequestService.CombineUrlPaths(cookiePolicyUrlBuilder.Path, "cookie-policy");
 
-        var noConsentHTML = new HtmlString(
+        var noConsentHtml = new HtmlString(
             "<div>" +
             stringLocalizer["The content of this section includes tracking functionality. To view it, please consent to Marketing cookies."] +
             $"</div><div>"
@@ -62,7 +62,7 @@ public class FormColumnSectionConsentViewComponent : ViewComponent
         {
             SectionAnchor = sectionProperties.Properties.SectionAnchor,
             ShowContents = showContents,
-            NoConsentHTML = noConsentHTML
+            NoConsentHtml = noConsentHtml
         };
 
         return View("~/Features/Shared/Sections/FormColumn/FormColumnSection.cshtml", model);

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Html;
-
-namespace TrainingGuides.Web.Features.Shared.Sections.FormColumn;
+﻿namespace TrainingGuides.Web.Features.Shared.Sections.FormColumn;
 
 public class FormColumnSectionViewModel
 {
     public bool ShowContents { get; set; }
     public string SectionAnchor { get; set; } = string.Empty;
-    public HtmlString NoConsentHtml { get; set; } = new HtmlString(string.Empty);
+    public string NoConsentMessage { get; set; } = string.Empty;
+    public string NoConsentLinkText { get; set; } = string.Empty;
+    public string NoConsentLinkUrl { get; set; } = string.Empty;
 }

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
@@ -6,5 +6,5 @@ public class FormColumnSectionViewModel
 {
     public bool ShowContents { get; set; }
     public string SectionAnchor { get; set; } = string.Empty;
-    public HtmlString NoConsentHTML { get; set; } = new HtmlString(string.Empty);
+    public HtmlString NoConsentHtml { get; set; } = new HtmlString(string.Empty);
 }

--- a/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Sections/FormColumn/FormColumnSectionViewModel.cs
@@ -1,7 +1,10 @@
-﻿namespace TrainingGuides.Web.Features.Shared.Sections.FormColumn;
+﻿using Microsoft.AspNetCore.Html;
+
+namespace TrainingGuides.Web.Features.Shared.Sections.FormColumn;
 
 public class FormColumnSectionViewModel
 {
     public bool ShowContents { get; set; }
     public string SectionAnchor { get; set; } = string.Empty;
+    public HtmlString NoConsentHTML { get; set; } = new HtmlString(string.Empty);
 }


### PR DESCRIPTION
Adjust the 'Form column section: consent-based' Page Builder section to display a message when it hides its widget content from visitors who have not consented to tracking

# Motivation

Addresses #112, prevents confusion when page contents are hidden
