### PR TITLE
GH-125 update repo to use combined content selector /MB

### DIFF
--- a/src/TrainingGuides.Web/App_Data/CIRepository/@global/cms.contenttype/trainingguides.articlepage.xml
+++ b/src/TrainingGuides.Web/App_Data/CIRepository/@global/cms.contenttype/trainingguides.articlepage.xml
@@ -18,6 +18,7 @@
             <![CDATA[["17a2abf5-c412-4cee-8b6b-e5209bcd3e8c"]]]>
           </AllowedContentItemTypeIdentifiers>
           <controlname>Kentico.Administration.ContentItemSelector</controlname>
+          <MaximumItems>1</MaximumItems>
           <SelectionType>contentTypes</SelectionType>
         </settings>
       </field>
@@ -32,6 +33,7 @@
             <![CDATA[["c3b4896f-ba7c-4b75-9cd4-47afa7489ff1"]]]>
           </AllowedSchemaIdentifiers>
           <controlname>Kentico.Administration.ContentItemSelector</controlname>
+          <MaximumItems>1</MaximumItems>
           <SelectionType>reusableFieldSchemas</SelectionType>
         </settings>
       </field>

--- a/src/TrainingGuides.Web/Features/Articles/ArticlePagePageTemplate.cs
+++ b/src/TrainingGuides.Web/Features/Articles/ArticlePagePageTemplate.cs
@@ -10,6 +10,7 @@ using TrainingGuides.Web.Features.Articles;
     IconClass = "xp-a-lowercase")]
 
 namespace TrainingGuides.Web.Features.Articles;
+
 public static class ArticlePagePageTemplate
 {
     public const string IDENTIFIER = "TrainingGuides.ArticlePagePageTemplate";

--- a/src/TrainingGuides.Web/Features/Articles/Widgets/ArticleList/ArticleListWidgetProperties.cs
+++ b/src/TrainingGuides.Web/Features/Articles/Widgets/ArticleList/ArticleListWidgetProperties.cs
@@ -1,17 +1,24 @@
+using CMS.ContentEngine;
 using Kentico.PageBuilder.Web.Mvc;
 using Kentico.Xperience.Admin.Base.FormAnnotations;
-using Kentico.Xperience.Admin.Websites.FormAnnotations;
 
 namespace TrainingGuides.Web.Features.Articles.Widgets.ArticleList;
 
 public class ArticleListWidgetProperties : IWidgetProperties
 {
-    [WebPageSelectorComponent(
-        Label = "Select the content tree section",
-        MaximumPages = 1,
-        Sortable = true,
+    [ContentItemSelectorComponent(
+        [
+            ArticlePage.CONTENT_TYPE_NAME,
+            DownloadsPage.CONTENT_TYPE_NAME,
+            EmptyPage.CONTENT_TYPE_NAME,
+            LandingPage.CONTENT_TYPE_NAME,
+            ProductPage.CONTENT_TYPE_NAME
+        ],
+        Label = "Select a parent page to pull articles from",
+        AllowContentItemCreation = false,
+        MaximumItems = 1,
         Order = 10)]
-    public IEnumerable<WebPageRelatedItem> ContentTreeSection { get; set; } = Enumerable.Empty<WebPageRelatedItem>();
+    public IEnumerable<ContentItemReference> ContentTreeSection { get; set; } = Enumerable.Empty<ContentItemReference>();
 
     [NumberInputComponent(
         Label = "Number of articles to display",

--- a/src/TrainingGuides.Web/Features/Articles/Widgets/ArticleList/ArticleListWidgetViewComponent.cs
+++ b/src/TrainingGuides.Web/Features/Articles/Widgets/ArticleList/ArticleListWidgetViewComponent.cs
@@ -1,3 +1,4 @@
+using CMS.ContentEngine;
 using CMS.DataEngine;
 using Kentico.PageBuilder.Web.Mvc;
 using Microsoft.AspNetCore.Mvc;
@@ -52,12 +53,13 @@ public class ArticleListWidgetViewComponent : ViewComponent
         return View("~/Features/Articles/Widgets/ArticleList/ArticleListWidget.cshtml", model);
     }
 
-    private async Task<IEnumerable<ArticlePage>> RetrieveArticlePages(WebPageRelatedItem parentPageSelection)
+    private async Task<IEnumerable<ArticlePage>> RetrieveArticlePages(ContentItemReference parentPageSelection)
     {
-        var selectedPageGuid = parentPageSelection.WebPageGuid;
+        var selectedPageGuid = parentPageSelection.Identifier;
 
-        var selectedPage = await genericPageRetrieverService.RetrieveWebPageByGuid(selectedPageGuid);
-        string selectedPageContentTypeName = await GetWebPageContentTypeName(selectedPageGuid);
+        var selectedPage = await genericPageRetrieverService.RetrieveWebPageByContentItemGuid(selectedPageGuid);
+        var selectedPageWebPageGuid = selectedPage?.SystemFields.WebPageItemGUID;
+        string selectedPageContentTypeName = await GetWebPageContentTypeName(selectedPageWebPageGuid);
         string selectedPagePath = selectedPage?.SystemFields.WebPageItemTreePath ?? string.Empty;
 
         if (string.IsNullOrEmpty(selectedPagePath))
@@ -71,7 +73,7 @@ public class ArticleListWidgetViewComponent : ViewComponent
             3);
     }
 
-    private async Task<string> GetWebPageContentTypeName(Guid id)
+    private async Task<string> GetWebPageContentTypeName(Guid? id)
     {
         // database-related string constants, needed to retrieve Page content type name
         const string WEB_PAGE_ITEM_OBJECT_TYPE = "cms.webpageitem";

--- a/src/TrainingGuides.Web/Features/Articles/Widgets/FeaturedArticle/FeaturedArticleWidgetProperties.cs
+++ b/src/TrainingGuides.Web/Features/Articles/Widgets/FeaturedArticle/FeaturedArticleWidgetProperties.cs
@@ -1,14 +1,15 @@
+using CMS.ContentEngine;
 using Kentico.PageBuilder.Web.Mvc;
-using Kentico.Xperience.Admin.Websites.FormAnnotations;
+using Kentico.Xperience.Admin.Base.FormAnnotations;
 
 namespace TrainingGuides.Web.Features.Articles.Widgets.FeaturedArticle;
 
 public class FeaturedArticleWidgetProperties : IWidgetProperties
 {
-    [WebPageSelectorComponent(
+    [ContentItemSelectorComponent(
+        ArticlePage.CONTENT_TYPE_NAME,
         Label = "Selected article",
-        MaximumPages = 1,
-        Sortable = true,
+        MaximumItems = 1,
         Order = 10)]
-    public IEnumerable<WebPageRelatedItem> Article { get; set; } = Enumerable.Empty<WebPageRelatedItem>();
+    public IEnumerable<ContentItemReference> Article { get; set; } = Enumerable.Empty<ContentItemReference>();
 }

--- a/src/TrainingGuides.Web/Features/Articles/Widgets/FeaturedArticle/FeaturedArticleWidgetViewComponent.cs
+++ b/src/TrainingGuides.Web/Features/Articles/Widgets/FeaturedArticle/FeaturedArticleWidgetViewComponent.cs
@@ -28,9 +28,9 @@ public class FeaturedArticleWidgetViewComponent : ViewComponent
 
     public async Task<ViewViewComponentResult> InvokeAsync(FeaturedArticleWidgetProperties properties)
     {
-        var guid = properties.Article?.Select(i => i.WebPageGuid).FirstOrDefault();
+        var guid = properties.Article?.Select(i => i.Identifier).FirstOrDefault();
         var articlePage = guid.HasValue
-            ? await articlePageRetrieverService.RetrieveWebPageByGuid(
+            ? await articlePageRetrieverService.RetrieveWebPageByContentItemGuid(
                 guid.Value,
                 ArticlePage.CONTENT_TYPE_NAME,
                 3)

--- a/src/TrainingGuides.Web/Features/Header/Header.cshtml
+++ b/src/TrainingGuides.Web/Features/Header/Header.cshtml
@@ -1,7 +1,7 @@
 @model TrainingGuides.Web.Features.Header.HeaderViewModel
 
 <header class="c-header sticky-top">
-    <nav class="navbar navbar-expand-md c-main-navbar">
+    <nav class="navbar d-flex p-2 container">
         <div id="navbar-container">
             <h1>@Model.Heading</h1>
         </div>

--- a/src/TrainingGuides.Web/Features/Shared/Services/ContentItemRetrieverService.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Services/ContentItemRetrieverService.cs
@@ -20,14 +20,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         this.preferredLanguageRetriever = preferredLanguageRetriever;
     }
 
-
-    /// <summary>
-    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="webPageItemId">The Id of the Web page content item.</param>
-    /// <param name="contentTypeName">Content type name of the Web page.</param>
-    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
-    /// <returns>A Web page content item of specified type, with the specifiied Id</returns>
+    /// <inheritdoc />
     public async Task<T?> RetrieveWebPageById(
         int webPageItemId,
         string contentTypeName,
@@ -44,13 +37,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         return pages.FirstOrDefault();
     }
 
-    /// <summary>
-    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="webPageItemGuid">The Guid of the Web page content item.</param>
-    /// <param name="contentTypeName">Content type name of the Web page.</param>
-    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
-    /// <returns>A Web page content item of specified type, with the specifiied Id</returns>
+    /// <inheritdoc />
     public async Task<T?> RetrieveWebPageByGuid(
         Guid? webPageItemGuid,
         string contentTypeName,
@@ -67,15 +54,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         return pages.FirstOrDefault();
     }
 
-    /// <summary>
-    /// Retrieves Web page content item by ContentItemGuid using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="contentItemGuid">The content item Guid of the Web page content item.</param>
-    /// <param name="contentTypeName">Content type name of the Web page.</param>
-    /// <param name="language">The language of the content item. If null, the language will be inferred from the URL of the current request.</param>
-    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
-    /// <param name="languageName">The language to query. If null, the language will be inferred from the URL of the current request.</param>
-    /// <returns>A web page content item of the specified type, with the specified content item Guid</returns>
+    /// <inheritdoc />
     public async Task<T?> RetrieveWebPageByContentItemGuid(
         Guid contentItemGuid,
         string contentTypeName,
@@ -86,19 +65,12 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
             contentTypeName,
             innerParams => innerParams.WithLinkedItems(depth),
             outerParams => outerParams
-                .Where(where => where.WhereEquals(nameof(WebPageFields.ContentItemGUID), contentItemGuid)),
+                .Where(where => where.WhereEquals(nameof(ContentItemFields.ContentItemGUID), contentItemGuid)),
             languageName: languageName);
         return pages.FirstOrDefault();
     }
 
-    /// <summary>
-    /// Retrieves web page content items using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="contentTypeName">Content type name of the Web page.</param>
-    /// <param name="innerQueryFilter">Filter for ForContentTypes parameterization</param>
-    /// <param name="outerParams">Outer query parameterization</param>
-    /// <param name="languageName">Determines the language of the retrieved content. PreferredLanguageRetriever is used if empty</param>
-    /// <returns>An enumerable set of items</returns>
+    /// <inheritdoc />
     public async Task<IEnumerable<T>> RetrieveWebPageContentItems(
         string contentTypeName,
         Func<ContentTypesQueryParameters, ContentTypesQueryParameters> innerQueryFilter,
@@ -124,13 +96,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         return pages;
     }
 
-    /// <summary>
-    /// Retrieves child pages of a given web page.
-    /// </summary>
-    /// <param name="parentPageContentTypeName">Content type of the parent page</param>
-    /// <param name="parentPagePath">Path of the parent page</param>
-    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<IEnumerable<T>> RetrieveWebPageChildrenByPath(
         string parentPageContentTypeName,
         string parentPagePath,
@@ -155,13 +121,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         return pages;
     }
 
-    /// <summary>
-    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="contentItemGuid">The Guid of the reusable content item.</param>
-    /// <param name="contentTypeName">Content type name of the Web page.</param>
-    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
-    /// <returns>A Web page content item of specified type, with the specified Id</returns>
+    /// <inheritdoc />
     public async Task<T?> RetrieveContentItemByGuid(
         Guid contentItemGuid,
         string contentTypeName,
@@ -177,12 +137,7 @@ public class ContentItemRetrieverService<T> : IContentItemRetrieverService<T>
         return items.FirstOrDefault();
     }
 
-    /// <summary>
-    /// Retrieves reusable content items using ContentItemQueryBuilder
-    /// </summary>
-    /// <param name="contentTypeName">Content type name of the reusable item.</param>
-    /// <param name="queryFilter">A delegate used to configure query for given contentTypeName</param>
-    /// <returns>An enumerable set of items</returns>
+    /// <inheritdoc />
     public async Task<IEnumerable<T>> RetrieveReusableContentItems(
         string contentTypeName,
         Func<ContentTypeQueryParameters, ContentTypeQueryParameters> queryFilter,
@@ -211,25 +166,25 @@ public class ContentItemRetrieverService : IContentItemRetrieverService
     private readonly IContentQueryExecutor contentQueryExecutor;
     private readonly IWebsiteChannelContext websiteChannelContext;
 
+    private readonly IPreferredLanguageRetriever preferredLanguageRetriever;
+
     public ContentItemRetrieverService(
         IContentQueryExecutor contentQueryExecutor,
-        IWebsiteChannelContext websiteChannelContext)
+        IWebsiteChannelContext websiteChannelContext,
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         this.contentQueryExecutor = contentQueryExecutor;
         this.websiteChannelContext = websiteChannelContext;
+        this.preferredLanguageRetriever = preferredLanguageRetriever;
     }
 
-    /// <summary>
-    /// Retrieves the IWebPageFieldsSource of a web page item by Guid.
-    /// </summary>
-    /// <param name="webPageItemGuid">the Guid of the web page item</param>
-    /// <returns><see cref="IWebPageFieldsSource"/> object containing generic <see cref="WebPageFields"/> for the item</returns>
-    public async Task<IWebPageFieldsSource?> RetrieveWebPageByGuid(
-        Guid webPageItemGuid)
+    /// <inheritdoc />
+    public async Task<IWebPageFieldsSource?> RetrieveWebPageByContentItemGuid(
+        Guid pageContentItemGuid)
     {
         var pages = await RetrieveWebPages(parameters =>
             {
-                parameters.Where(where => where.WhereEquals(nameof(WebPageFields.WebPageItemGUID), webPageItemGuid));
+                parameters.Where(where => where.WhereEquals(nameof(ContentItemFields.ContentItemGUID), pageContentItemGuid));
             });
 
         return pages.FirstOrDefault();
@@ -248,14 +203,18 @@ public class ContentItemRetrieverService : IContentItemRetrieverService
 
     private async Task<IEnumerable<IWebPageFieldsSource>> RetrieveWebPages(Action<ContentQueryParameters> parameters)
     {
-        var builder = new ContentItemQueryBuilder();
+        var builder = new ContentItemQueryBuilder()
+            .ForContentTypes(query => query
+            .WithLinkedItems(2, options => options.IncludeWebPageData(true))
+            .ForWebsite(websiteChannelContext.WebsiteChannelName))
+        .Parameters(parameters)
+        .InLanguage(preferredLanguageRetriever.Get());
 
-        builder.ForContentTypes(query =>
-            {
-                query.ForWebsite(websiteChannelContext.WebsiteChannelName);
-            })
-            .Parameters(parameters);
+        var queryExecutorOptions = new ContentQueryExecutionOptions
+        {
+            ForPreview = websiteChannelContext.IsPreview
+        };
 
-        return await contentQueryExecutor.GetMappedResult<IWebPageFieldsSource>(builder);
+        return await contentQueryExecutor.GetMappedResult<IWebPageFieldsSource>(builder, queryExecutorOptions);
     }
 }

--- a/src/TrainingGuides.Web/Features/Shared/Services/IContentItemRetrieverService.cs
+++ b/src/TrainingGuides.Web/Features/Shared/Services/IContentItemRetrieverService.cs
@@ -4,36 +4,93 @@ namespace TrainingGuides.Web.Features.Shared.Services;
 
 public interface IContentItemRetrieverService<T>
 {
+    /// <summary>
+    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="webPageItemId">The Id of the Web page content item.</param>
+    /// <param name="contentTypeName">Content type name of the Web page.</param>
+    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
+    /// <returns>A Web page content item of specified type, with the specified Id</returns>
     Task<T?> RetrieveWebPageById(
         int webPageItemId,
         string contentTypeName,
         int depth = 1,
         string? languageName = null);
 
+    /// <summary>
+    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="webPageItemGuid">The Guid of the Web page content item.</param>
+    /// <param name="contentTypeName">Content type name of the Web page.</param>
+    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
+    /// <returns>A Web page content item of specified type, with the specified Id</returns>
     Task<T?> RetrieveWebPageByGuid(
         Guid? webPageItemGuid,
         string contentTypeName,
         int depth = 1,
         string? languageName = null);
 
+    /// <summary>
+    /// Retrieves Web page content item by ContentItemGuid using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="contentItemGuid">The content item Guid of the Web page content item.</param>
+    /// <param name="contentTypeName">Content type name of the Web page.</param>
+    /// <param name="language">The language of the content item. If null, the language will be inferred from the URL of the current request.</param>
+    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
+    /// <param name="languageName">The language to query. If null, the language will be inferred from the URL of the current request.</param>
+    /// <returns>A web page content item of the specified type, with the specified content item Guid</returns>
     Task<T?> RetrieveWebPageByContentItemGuid(
         Guid contentItemGuid,
         string contentTypeName,
         int depth = 1,
         string? languageName = null);
 
+    /// <summary>
+    /// Retrieves web page content items using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="contentTypeName">Content type name of the Web page.</param>
+    /// <param name="innerQueryFilter">Filter for ForContentTypes parameterization</param>
+    /// <param name="outerParams">Outer query parameterization</param>
+    /// <param name="languageName">Determines the language of the retrieved content. PreferredLanguageRetriever is used if empty</param>
+    /// <returns>An enumerable set of items</returns>
+    Task<IEnumerable<T>> RetrieveWebPageContentItems(
+        string contentTypeName,
+        Func<ContentTypesQueryParameters, ContentTypesQueryParameters> innerQueryFilter,
+        Action<ContentQueryParameters> outerParams,
+        string? languageName = null);
+
+    /// <summary>
+    /// Retrieves child pages of a given web page.
+    /// </summary>
+    /// <param name="parentPageContentTypeName">Content type of the parent page</param>
+    /// <param name="parentPagePath">Path of the parent page</param>
+    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
+    /// <returns></returns>
     Task<IEnumerable<T>> RetrieveWebPageChildrenByPath(
         string parentPageContentTypeName,
         string path,
         int depth = 1,
         string? languageName = null);
 
+    /// <summary>
+    /// Retrieves Web page content item by Id using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="contentItemGuid">The Guid of the reusable content item.</param>
+    /// <param name="contentTypeName">Content type name of the Web page.</param>
+    /// <param name="depth">The maximum level of recursively linked content items that should be included in the results. Default value is 1.</param>
+    /// <returns>A Web page content item of specified type, with the specified Id</returns>
     Task<T?> RetrieveContentItemByGuid(
         Guid contentItemGuid,
         string contentTypeName,
         int depth = 1,
         string? languageName = null);
 
+    /// <summary>
+    /// Retrieves reusable content items using ContentItemQueryBuilder
+    /// </summary>
+    /// <param name="contentTypeName">Content type name of the reusable item.</param>
+    /// <param name="queryFilter">A delegate used to configure query for given contentTypeName</param>
+    /// <returns>An enumerable set of items</returns>
     Task<IEnumerable<T>> RetrieveReusableContentItems(
         string contentTypeName,
         Func<ContentTypeQueryParameters, ContentTypeQueryParameters> queryFilter,
@@ -42,6 +99,11 @@ public interface IContentItemRetrieverService<T>
 
 public interface IContentItemRetrieverService
 {
-    Task<IWebPageFieldsSource?> RetrieveWebPageByGuid(Guid webPageItemGuid);
+    /// <summary>
+    /// Retrieves the IWebPageFieldsSource of a web page item by Guid.
+    /// </summary>
+    /// <param name="pageContentItemGuid">the Guid of the web page item</param>
+    /// <returns><see cref="IWebPageFieldsSource"/> object containing generic <see cref="WebPageFields"/> for the item</returns>
+    Task<IWebPageFieldsSource?> RetrieveWebPageByContentItemGuid(Guid pageContentItemGuid);
 
 }

--- a/src/TrainingGuides.Web/Views/Shared/_Layout.cshtml
+++ b/src/TrainingGuides.Web/Views/Shared/_Layout.cshtml
@@ -28,7 +28,7 @@
 <body class="p-hp t-default">
     <div class="page-wrapper">
         <vc:header />
-        <div class="content-wrapper">
+        <div class="content-wrapper container">
             @RenderBody()
         </div>
         <footer class="c-footer">


### PR DESCRIPTION
# Motivation

Partially fixes #125 for the _main_ (starter) branch updating the repo to use solely the Combines content selector (never the Page selector). The updates include the way content is retrieved and the way we handle multilingual URLs.